### PR TITLE
V1.01

### DIFF
--- a/config/clash.yaml
+++ b/config/clash.yaml
@@ -1,0 +1,252 @@
+mixed-port: 7890
+allow-lan: false
+bind-address: '*'
+mode: rule
+log-level: info
+ipv6: false
+external-controller: 127.0.0.1:9090
+hosts:
+  'mtalk.google.com': 108.177.125.188
+  'dl.google.com': 180.163.151.161
+  'dl.l.google.com': 180.163.151.161
+profile:
+  store-selected: false
+dns:
+  enable: true
+  listen: 0.0.0.0:53
+  default-nameserver:
+    - 223.5.5.5
+  enhanced-mode: fake-ip
+  fake-ip-range: 198.18.0.1/16
+  fake-ip-filter:
+    - '*.lan'
+    - 'time.windows.com'
+    - 'time.nist.gov'
+    - 'time.apple.com'
+    - 'time.asia.apple.com'
+    - '*.ntp.org.cn'
+    - '*.openwrt.pool.ntp.org'
+    - 'time1.cloud.tencent.com'
+    - 'time.ustc.edu.cn'
+    - 'pool.ntp.org'
+    - 'ntp.ubuntu.com'
+    - 'ntp.aliyun.com'
+    - 'ntp1.aliyun.com'
+    - 'ntp2.aliyun.com'
+    - 'ntp3.aliyun.com'
+    - 'ntp4.aliyun.com'
+    - 'ntp5.aliyun.com'
+    - 'ntp6.aliyun.com'
+    - 'ntp7.aliyun.com'
+    - 'time1.aliyun.com'
+    - 'time2.aliyun.com'
+    - 'time3.aliyun.com'
+    - 'time4.aliyun.com'
+    - 'time5.aliyun.com'
+    - 'time6.aliyun.com'
+    - 'time7.aliyun.com'
+    - '*.time.edu.cn'
+    - 'time1.apple.com'
+    - 'time2.apple.com'
+    - 'time3.apple.com'
+    - 'time4.apple.com'
+    - 'time5.apple.com'
+    - 'time6.apple.com'
+    - 'time7.apple.com'
+    - 'time1.google.com'
+    - 'time2.google.com'
+    - 'time3.google.com'
+    - 'time4.google.com'
+    - 'music.163.com'
+    - '*.music.163.com'
+    - '*.126.net'
+    - 'musicapi.taihe.com'
+    - 'music.taihe.com'
+    - 'songsearch.kugou.com'
+    - 'trackercdn.kugou.com'
+    - '*.kuwo.cn'
+    - 'api-jooxtt.sanook.com'
+    - 'api.joox.com'
+    - 'joox.com'
+    - 'y.qq.com'
+    - '*.y.qq.com'
+    - 'streamoc.music.tc.qq.com'
+    - 'mobileoc.music.tc.qq.com'
+    - 'isure.stream.qqmusic.qq.com'
+    - 'dl.stream.qqmusic.qq.com'
+    - 'aqqmusic.tc.qq.com'
+    - 'amobile.music.tc.qq.com'
+    - '*.xiami.com'
+    - '*.music.migu.cn'
+    - 'music.migu.cn'
+    - '*.msftconnecttest.com'
+    - '*.msftncsi.com'
+    - 'localhost.ptlogin2.qq.com'
+    - '*.*.*.srv.nintendo.net'
+    - '*.*.stun.playstation.net'
+    - 'xbox.*.*.microsoft.com'
+    - '*.*.xboxlive.com'
+    - '*.taobao.com'
+    - '*.*.taobao.com'
+    - '*.*.*.taobao.com'
+    - 'taobao.com'
+    - '*.alicdn.com'
+  nameserver:
+    - https://223.5.5.5/dns-query
+  fallback:
+    - https://1.1.1.1/dns-query
+  fallback-filter:
+    geoip: true
+    ipcidr:
+      - 240.0.0.0/4
+proxies:
+
+proxy-groups:
+    - { name: 全球加速, type: select, proxies: [香港Fallback, 香港标准节点, 香港节点, 台湾节点, 日本节点, 新加坡隐私节点, 美国节点, DIRECT] }
+    - { name: 国内媒体, type: select, proxies: [DIRECT, 香港Fallback, 香港标准节点, 香港节点, 台湾节点, 日本节点] }
+    - { name: 国际媒体, type: select, proxies: [全球加速, 香港标准节点, 香港节点, 台湾节点, 日本节点, 新加坡隐私节点, 美国节点] }
+    - { name: 游戏加速, type: select, proxies: [全球加速, 特惠节点, DIRECT, 香港标准节点, 香港节点, 台湾节点, 日本节点, 新加坡隐私节点, 美国节点] }
+    - { name: 游戏下载, type: select, proxies: [特惠节点, DIRECT, 全球加速] }
+    - { name: Speedtest, type: select, proxies: [全球加速, DIRECT, 香港标准节点, 香港节点, 台湾节点, 日本节点, 新加坡隐私节点, 美国节点] }
+    - { name: Telegram, type: select, proxies: [新加坡隐私节点, 全球加速, DIRECT, 香港标准节点, 香港节点, 台湾节点, 日本节点, 美国节点] }
+    - { name: Microsoft, type: select, proxies: [DIRECT, 特惠节点, 全球加速, 新加坡隐私节点] }
+    - { name: Bing, type: select, proxies: [DIRECT, 特惠节点, 全球加速, 新加坡隐私节点] }
+    - { name: Apple, type: select, proxies: [DIRECT, 特惠节点, 全球加速, 新加坡隐私节点] }
+    - { name: 香港Fallback, type: fallback, proxies: ['[香港Anycast]海南BGP TV', 香港标准节点, 香港节点], url: 'http://www.gstatic.com/generate_204', interval: 86400 }
+    - { name: 香港节点, type: url-test, proxies: [ '[香港Anycast]福建BGP TV', '[香港Anycast]海南BGP TV', '[香港企宽]福建BGP TV', '[香港企宽2]香港BGP TV', '[香港企宽3]三亚BGP TV', '[香港企宽4]海南BGP TV', '[香港MS1]广港AGA加速 TV', '[香港MS2]融合BGP入口 TV', '[香港MS3]海南BGP入口 TV', '[香港MS4]福建BGP入口 TV', '[香港MS5]三亚CMIN2入口 TV', '[香港1环球电讯]BGP 原生IP TV', '[香港2环球电讯]三亚BGP 原生IP TV', '[香港2A环球电讯]海南BGP 原生IP TV', '[香港3]NTT CN2/9929入口 TV', '[香港4]NTT 三亚移动入口 TV', '[香港5]NTT CN2/9929 入口 TV', '[香港7]MS 三网CN2GIA入口 超大带宽低延迟节点', '[香港7-IPLC]三亚CMI 超大带宽低延迟节点', '[香港7-HN]海南BGP 超大带宽低延迟节点', '[香港7-2]MS 三网CN2GIA入口 TV 超大带宽低延迟节点', '[香港7-2]福建BGP入口 TV 超大带宽低延迟节点', '[香港7-HN]海南BGP入口 TV 超大带宽低延迟节点', '[香港8]DM CN2/9929 入口 TV', '[香港8-2]DM 三亚移动入口 TV', '[香港8-CM]DM 海口电信入口 TV', '[香港9]DM 海口电信 TV', '[香港10]DM 福州电信 TV', '[香港11]HGC原生 海南BGP入口 TV', '[香港12]HGC原生 浙江BGP入口 TV'], url: 'http://www.gstatic.com/generate_204', interval: 86400 }
+    - { name: 香港标准节点, type: url-test, proxies: [ '[香港Anycast]福建BGP TV', '[香港Anycast]海南BGP TV', '[香港企宽2]香港BGP TV', '[香港企宽3]三亚BGP TV', '[香港企宽4]海南BGP TV', '[香港MS3]海南BGP入口 TV', '[香港MS4]福建BGP入口 TV', '[香港MS5]三亚CMIN2入口 TV', '[香港1环球电讯]BGP 原生IP TV', '[香港2环球电讯]三亚BGP 原生IP TV', '[香港2A环球电讯]海南BGP 原生IP TV', '[香港4]NTT 三亚移动入口 TV', '[香港5]NTT CN2/9929 入口 TV', '[香港7-IPLC]三亚CMI 超大带宽低延迟节点', '[香港7-HN]海南BGP 超大带宽低延迟节点', '[香港7-HN]海南BGP入口 TV 超大带宽低延迟节点', '[香港10]DM 福州电信 TV', '[香港11]HGC原生 海南BGP入口 TV', '[香港12]HGC原生 浙江BGP入口 TV'], url: 'http://www.gstatic.com/generate_204', interval: 86400 }
+    - { name: 台湾节点, type: url-test, proxies: [ '[台湾1]新北 安徽BGP入口 TV', '[台湾2]新北 三亚BGP入口 TV', '[台湾3]新北 海南BGP入口 TV'], url: 'http://www.gstatic.com/generate_204', interval: 86400 }
+    - { name: 日本节点, type: url-test, proxies: [ '[日本1]Nico BGP入口 TV', '[日本2]Nico 湘潭BGP入口 TV', '[日本3]Nico 电联入口 TV', '[日本4]Cat CN2入口 TV', '[日本5]Cat 湘潭BGP入口 TV', '[日本6]Cat 杭州BGP入口 TV', '[日本7]NTT CN2入口 TV', '[日本8]NTT 湘潭BGP入口 TV', '[日本9]NTT 杭州BGP入口 TV'], url: 'http://www.gstatic.com/generate_204', interval: 86400 }
+    - { name: 新加坡隐私节点, type: url-test, proxies: [ '[新加坡]BGP 隐私专线入口 TV', '[新加坡1]海南BGP 隐私专线入口 TV', '[新加坡2]福建BGP 推荐 隐私专线入口 TV', '[新加坡3]沪新IPLC  隐私专线入口 TV', '[新加坡4]海南BGP  隐私专线入口 TV', '[新加坡5]湘潭BGP 隐私专线入口 TV'], url: 'http://www.gstatic.com/generate_204', interval: 86400 }
+    - { name: 美国节点, type: url-test, proxies: [ '[美国1]洛杉矶 BGP入口 TV', '[美国2]洛杉矶 长沙BGP入口 TV', '[美国3]洛杉矶 南方BGP入口 TV', '[美国4]旧金山 日美NCP入口 TV', '[美国5]旧金山 BGP入口 TV', '[美国6]加州 9929VIP入口 TV'], url: 'http://www.gstatic.com/generate_204', interval: 86400 }
+    - { name: 特惠节点, type: url-test, proxies: ['[香港Anycast]海南BGP TV', '[台湾2]新北 三亚BGP入口 TV', '[越南1]新越BGP TV', '[印尼]BGP入口 TV', '[荷兰VIP-3]10G 下载专用入口 TV', '[印度1]孟买 新印BGP入口 TV', '[印度2]孟买 港印BGP入口 TV'], url: 'http://www.gstatic.com/generate_204', interval: 86400 }
+
+rule-providers: 
+  Unbreak:
+    type: http
+    behavior: classical
+    path: "./rule_provider/Direct.yaml"
+    url: https://ghproxy.com/https://raw.githubusercontent.com/blackmatrix7/ios_rule_script/master/rule/Clash/Direct/Direct.yaml
+    interval: 86400
+  Hijacking:
+    type: http
+    behavior: classical
+    path: "./rule_provider/Hijacking.yaml"
+    url: https://ghproxy.com/https://raw.githubusercontent.com/DivineEngine/Profiles/master/Clash/RuleSet/Guard/Hijacking.yaml
+    interval: 86400
+  Privacy:
+    type: http
+    behavior: classical
+    path: "./rule_provider/Privacy.yaml"
+    url: https://ghproxy.com/https://raw.githubusercontent.com/blackmatrix7/ios_rule_script/master/rule/Clash/Privacy/Privacy.yaml
+    interval: 86400
+  Streaming:
+    type: http
+    behavior: classical
+    path: "./rule_provider/Streaming.yaml"
+    url: https://ghproxy.com/https://raw.githubusercontent.com/DivineEngine/Profiles/master/Clash/RuleSet/StreamingMedia/Streaming.yaml
+    interval: 86400
+  StreamingSE:
+    type: http
+    behavior: classical
+    path: "./rule_provider/StreamingSE.yaml"
+    url: https://ghproxy.com/https://raw.githubusercontent.com/DivineEngine/Profiles/master/Clash/RuleSet/StreamingMedia/StreamingSE.yaml
+    interval: 86400
+  Global:
+    type: http
+    behavior: classical
+    path: "./rule_provider/Global.yaml"
+    url: https://ghproxy.com/https://raw.githubusercontent.com/DivineEngine/Profiles/master/Clash/RuleSet/Global.yaml
+    interval: 86400
+  China:
+    type: http
+    behavior: classical
+    path: "./rule_provider/China.yaml"
+    url: https://ghproxy.com/https://raw.githubusercontent.com/DivineEngine/Profiles/master/Clash/RuleSet/China.yaml
+    interval: 86400
+  ChinaMax_Classical:
+    type: http
+    behavior: classical
+    path: "./rule_provider/ChinaMax_Classical.yaml"
+    url: https://ghproxy.com/https://raw.githubusercontent.com/blackmatrix7/ios_rule_script/master/rule/Clash/ChinaMax/ChinaMax_Classical.yaml
+    interval: 86400
+  Speedtest:
+    type: http
+    behavior: classical
+    path: "./rule_provider/speedtest.yaml"
+    url: https://ghproxy.com/https://raw.githubusercontent.com/blackmatrix7/ios_rule_script/master/rule/Clash/Speedtest/Speedtest.yaml
+    interval: 86400
+  Telegram:
+    type: http
+    behavior: classical
+    path: "./rule_provider/Telegram.yaml"
+    url: https://ghproxy.com/https://raw.githubusercontent.com/DivineEngine/Profiles/master/Clash/RuleSet/Extra/Telegram/Telegram.yaml
+    interval: 86400
+  Game:
+    type: http
+    behavior: classical
+    path: "./rule_provider/Game.yaml"
+    url: https://ghproxy.com/https://raw.githubusercontent.com/blackmatrix7/ios_rule_script/master/rule/Clash/Game/Game.yaml
+    interval: 86400
+  Microsoft:
+    type: http
+    behavior: classical
+    path: "./rule_provider/Microsoft.yaml"
+    url: https://ghproxy.com/https://raw.githubusercontent.com/blackmatrix7/ios_rule_script/master/rule/Clash/Microsoft/Microsoft.yaml
+    interval: 86400
+  Bing:
+    type: http
+    behavior: classical
+    path: "./rule_provider/Bing.yaml"
+    url: https://ghproxy.com/https://raw.githubusercontent.com/Toyro7356/QuantumultX/main/Bing.yaml
+    interval: 86400
+  Apple:
+    type: http
+    behavior: classical
+    path: "./rule_provider/Apple.yaml"
+    url: https://ghproxy.com/https://raw.githubusercontent.com/blackmatrix7/ios_rule_script/master/rule/Clash/Apple/Apple.yaml
+    interval: 86400
+  GameDownload:
+    type: http
+    behavior: classical
+    path: "./rule_provider/GameDownload.yaml"
+    url: https://ghproxy.com/https://raw.githubusercontent.com/Toyro7356/QuantumultX/main/GameDownload.yaml
+    interval: 86400
+  Taobao:
+    type: http
+    behavior: classical
+    path: "./rule_provider/Taobao.yaml"
+    url: https://ghproxy.com/https://raw.githubusercontent.com/blackmatrix7/ios_rule_script/master/rule/Clash/Alibaba/Alibaba.yaml
+    interval: 86400 
+rules:
+  - DOMAIN-SUFFIX,msftconnecttest.com,全球加速
+  - DOMAIN-SUFFIX,msftncsi.com,全球加速
+  - RULE-SET,Unbreak,DIRECT
+  - RULE-SET,Privacy,REJECT
+  - RULE-SET,Hijacking,REJECT
+  - RULE-SET,Taobao,DIRECT
+  - RULE-SET,Bing,Bing
+  - RULE-SET,Microsoft,Microsoft
+  - RULE-SET,GameDownload,游戏下载
+  - RULE-SET,Game,游戏加速
+  - RULE-SET,Telegram,Telegram
+  - RULE-SET,Speedtest,Speedtest
+  - RULE-SET,Apple,Apple
+  - RULE-SET,StreamingSE,国内媒体
+  - RULE-SET,Streaming,国际媒体
+  - DOMAIN,lens.l.google.com,美国节点
+  - RULE-SET,China,DIRECT
+  - RULE-SET,ChinaMax_Classical,DIRECT
+  - RULE-SET,Global,全球加速
+  - IP-CIDR,192.168.0.0/16,DIRECT
+  - IP-CIDR,10.0.0.0/8,DIRECT
+  - IP-CIDR,172.16.0.0/12,DIRECT
+  - IP-CIDR,127.0.0.0/8,DIRECT
+  - IP-CIDR,100.64.0.0/10,DIRECT
+  - IP-CIDR,224.0.0.0/4,DIRECT
+  - IP-CIDR,fe80::/10,DIRECT
+  - IP-CIDR,119.28.28.28/32,DIRECT
+  - IP-CIDR,182.254.116.0/24,DIRECT
+  - IP-CIDR,198.18.0.1/16,REJECT,no-resolve
+  - GEOIP,CN,DIRECT
+  - MATCH,全球加速


### PR DESCRIPTION
V1.01
更新日志：
1、目前clash配置文件已并入主线项目，近期会进行多次更新和优化；
2、解决了部分网络环境下无法更新订阅规则的问题；
3、修复了在Fake-IP模式下Windows设备提示“无法访问Internet”的问题；
4、对Microsoft和Bing规则进行拆分，Bing支持单独切换国际版；
5、取消了默认去广告规则，后续版本仅提供隐私保护和反劫持规则的支援；
6、修复了淘宝APP有几率出现”网络繁忙“和”关闭代理“弹窗的Bug；
7、优化部分规则，提高可读性。

注意：
1、未来版本中将停止对ipv6网络和规则的支援，提高OpenClash的运行性能；
2、对部分历史遗留问题，如节点通配符和节点订阅链接支援等，逐步优化解决；
3、目前我的主线项目在Loon的配置文件上，OpenClash项目可能会有些许延迟。